### PR TITLE
fix: Correct broken navigation links in sidebar

### DIFF
--- a/frontend/src/app/shared/components/Sidebar.tsx
+++ b/frontend/src/app/shared/components/Sidebar.tsx
@@ -38,8 +38,7 @@ export function Sidebar({ isCollapsed = false, onToggleCollapse }: SidebarProps)
       label: 'My Tickets',
     },
     {
-      // BUG: Broken navigation link - typo in URL path
-      href: '/categoires', // Should be '/categories' - leads to 404 page
+      href: '/categories',
       icon: Tags,
       label: 'Categories',
     },
@@ -49,8 +48,7 @@ export function Sidebar({ isCollapsed = false, onToggleCollapse }: SidebarProps)
       label: 'Knowledge Base',
     },
     {
-      // BUG: Broken navigation link - incorrect URL path
-      href: '/user-profile', // Should be '/profile' - leads to 404 page
+      href: '/profile',
       icon: User,
       label: 'Profile',
     },
@@ -62,8 +60,7 @@ export function Sidebar({ isCollapsed = false, onToggleCollapse }: SidebarProps)
       label: 'My Tickets',
     },
     {
-      // BUG: Broken navigation link for regular users too
-      href: '/kb', // Should be '/knowledge-base' - leads to 404 page
+      href: '/knowledge-base',
       icon: BookOpen,
       label: 'Knowledge Base',
     },


### PR DESCRIPTION
Fixed three navigation issues:
- Fixed typo: '/categoires' → '/categories' (Agent Categories link)
- Fixed wrong path: '/user-profile' → '/profile' (Agent Profile link)
- Fixed wrong path: '/kb' → '/knowledge-base' (User Knowledge Base link)

All navigation links now correctly route to their intended pages.

Resolves broken user experience where clicking these links resulted in 404 errors.